### PR TITLE
upgrade toolchain to 1.95

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94"
+channel = "1.95"
 profile = "minimal"


### PR DESCRIPTION
## Summary
- Upgrade the Rust toolchain to 1.95.
- Rely on GitHub Actions for validation and investigate only failing checks.